### PR TITLE
Correct package name in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This module provides a ECMA-262 regular expression [acceptor](https://en.wikiped
 ## Installation
 
 ```sh
-npm install shift-regexp
+npm install shift-regexp-acceptor
 ```
 
 


### PR DESCRIPTION
404: https://www.npmjs.com/package/shift-regexp
Exists: https://www.npmjs.com/package/shift-regexp-acceptor